### PR TITLE
Add support/remove errors for PoolManager Chrlor (CI) PM5 controllers…

### DIFF
--- a/custom_components/bayrol_cloud/client/__init__.py
+++ b/custom_components/bayrol_cloud/client/__init__.py
@@ -34,6 +34,12 @@ class BayrolPoolAPI:
         """Get list of controllers from plants page."""
         return await self._client.get_controllers()
 
+#    async def get_data(self, cid: str) -> Dict[str, Any]:
+#        """Get pool data for a specific controller."""
+#        return await self._client.get_data(cid)
+    
     async def get_data(self, cid: str) -> Dict[str, Any]:
         """Get pool data for a specific controller."""
-        return await self._client.get_data(cid)
+        result = await self._client.get_data(cid)
+        _LOGGER.warning("Bayrol raw API result for controller %s: %s", cid, result)
+        return result


### PR DESCRIPTION
- Ensured compatibility with Bayrol PM5 Chlor (Cl) devices (software version v240729 (9.1.1)
- Added fallback logic to parse HTML-based responses when JSON is not returned (used by modern controllers).
- Replaced raw error() logs with debug() logs when non-JSON is detected (to prevent unnecessary integration errors).
- Improved debug logging to report parsing success/failure with detailed context.
- Silenced harmless log noise about missing i_x16 classes (no longer used in PM5 HTML).
- Patched __init__.py and http_client.py to avoid raising errors when JSON parsing fails (legacy fallback).