### PR TITLE
fix: replace deprecated async_timeout and FlowResult imports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - run: pip install -r requirements.txt
+      - run: python -m pytest -q

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,26 @@
+name: Validate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * 1"
+
+jobs:
+  hassfest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: home-assistant/actions/hassfest@master
+
+  hacs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hacs/action@main
+        with:
+          category: integration
+          # bayrol_cloud is not registered in home-assistant/brands (custom repo).
+          ignore: brands

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ wheels/
 
 # Virtual Environment
 venv/
+.venv/
 ENV/
 env/
 .env/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 # Bayrol Cloud Integration for Home Assistant
 
+> **Maintained fork.** This is an actively maintained fork of the original
+> [`razem-io/ha-bayrol-cloud`](https://github.com/razem-io/ha-bayrol-cloud),
+> which is no longer being updated. All credit for the original work goes to
+> [@razem-io](https://github.com/razem-io). Install from `katomm/ha-bayrol-cloud`
+> (see [Installation](#installation)) to get fixes and updates.
+
 ⚠️ **BETA STATUS**: This integration is currently in beta. Please report any issues you encounter.
 
 This is a Home Assistant Custom Component for the Bayrol Cloud. It allows you to monitor and control your pool's parameters and equipment directly in Home Assistant.
@@ -16,7 +22,7 @@ Currently tested with:
 - BAYROL PoolManager Chlor (Cl)
 - BAYROL PoolRelax CI
 
-Have a different Bayrol device? Please [open an issue](https://github.com/razem-io/ha-bayrol-cloud/issues) to help expand device support! When opening an issue, please include:
+Have a different Bayrol device? Please [open an issue](https://github.com/katomm/ha-bayrol-cloud/issues) to help expand device support! When opening an issue, please include:
 - Your device model
 - HTML response of https://www.bayrol-poolaccess.de/webview/getdata.php?cid=<your-cid>
 - Any specific features or parameters your device supports
@@ -62,7 +68,7 @@ Have a different Bayrol device? Please [open an issue](https://github.com/razem-
    - Click on "Integrations"
    - Click the three dots in the top right corner
    - Select "Custom repositories"
-   - Add `https://github.com/razem-io/ha-bayrol-cloud` as the repository URL
+   - Add `https://github.com/katomm/ha-bayrol-cloud` as the repository URL
    - Select "Integration" as the category
 3. Click "Install"
 4. Restart Home Assistant
@@ -128,7 +134,7 @@ switch.bayrol_cloud_12345_debug:
 
 ### Prerequisites
 
-- Python 3.9 or higher
+- Python 3.12 or higher
 - Home Assistant development environment
 - SSH access to your Home Assistant instance
 - `rsync` installed on your development machine
@@ -159,9 +165,22 @@ The script will:
 - Restart Home Assistant to apply changes
 - Wait for Home Assistant to come back online
 
-### Testing
+### Unit Tests
 
-A test script (`test_api.py`) is provided to verify the API connection before deploying to Home Assistant:
+The unit tests run offline (no credentials or network needed) and cover the HTML
+parsers and the integration setup/retry behaviour. They also run in CI on every
+push and pull request.
+
+```bash
+pip install -r requirements.txt
+pytest
+```
+
+### Live API Test Script
+
+A test script (`test_api.py`) is provided to verify the live API connection
+before deploying to Home Assistant. Unlike the unit tests, this one talks to the
+Bayrol Cloud and needs real credentials:
 
 ```bash
 python test_api.py --username your@email.com --password yourpassword --cid yourcid
@@ -206,7 +225,7 @@ The debug logs will show:
 
 ## Support
 
-For bugs, feature requests, or to add support for new devices, please [open an issue](https://github.com/razem-io/ha-bayrol-cloud/issues) on GitHub.
+For bugs, feature requests, or to add support for new devices, please [open an issue](https://github.com/katomm/ha-bayrol-cloud/issues) on GitHub.
 
 ## License
 

--- a/custom_components/bayrol_cloud/__init__.py
+++ b/custom_components/bayrol_cloud/__init__.py
@@ -1,9 +1,9 @@
 """The Bayrol Pool Controller integration."""
 from __future__ import annotations
 
+import asyncio
 import logging
 import aiohttp
-import async_timeout
 import voluptuous as vol
 from datetime import timedelta
 from typing import Any
@@ -99,7 +99,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def async_update_data():
         """Fetch data from API."""
         try:
-            async with async_timeout.timeout(30):
+            async with asyncio.timeout(30):
                 retry_count = 0
                 max_retries = 3
                 last_error = None

--- a/custom_components/bayrol_cloud/__init__.py
+++ b/custom_components/bayrol_cloud/__init__.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.update_coordinator import (
@@ -81,20 +82,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             retry_count += 1
 
         if not login_success:
-            _LOGGER.error("Failed to perform initial login after %d attempts", max_retries)
-            return False
+            # Raise ConfigEntryNotReady so HA retries setup with backoff instead
+            # of giving up permanently. This notably happens when DNS is not ready
+            # yet during a reboot: setup fails once and the integration would
+            # otherwise stay dead until the next manual restart.
+            raise ConfigEntryNotReady(
+                f"Failed to perform initial login after {max_retries} attempts"
+            )
 
         # Verify we can get data
         conditional_log(_LOGGER, logging.DEBUG, "Verifying data access...", debug_mode=api.debug_mode)
         data = await api.get_data(entry.data[CONF_CID])
         if not data:
-            _LOGGER.error("Failed to get initial data")
-            return False
+            raise ConfigEntryNotReady("Failed to get initial data")
         conditional_log(_LOGGER, logging.DEBUG, "Initial data fetch successful: %s", data, debug_mode=api.debug_mode)
 
+    except ConfigEntryNotReady:
+        # Already a retryable setup error, let HA handle the backoff/retry.
+        raise
     except Exception as err:
         _LOGGER.error("Error during initial setup: %s", err)
-        return False
+        raise ConfigEntryNotReady(f"Error during initial setup: {err}") from err
 
     async def async_update_data():
         """Fetch data from API."""

--- a/custom_components/bayrol_cloud/config_flow.py
+++ b/custom_components/bayrol_cloud/config_flow.py
@@ -10,8 +10,8 @@ import voluptuous as vol
 import aiohttp
 
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
@@ -189,7 +189,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle the initial step."""
         errors: dict[str, str] = {}
 
@@ -228,7 +228,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         
     async def async_step_select_controller(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle controller selection."""
         errors: dict[str, str] = {}
         
@@ -264,7 +264,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         
     async def async_step_controller(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle manual controller ID entry."""
         errors: dict[str, str] = {}
         
@@ -299,7 +299,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         
     async def async_step_controller_settings(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle settings password entry for a specific controller."""
         errors: dict[str, str] = {}
         
@@ -361,7 +361,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Create the options flow."""
         return OptionsFlowHandler(config_entry)
         
-    async def async_step_import(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+    async def async_step_import(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Handle import from configuration.yaml."""
         return await self.async_step_user(user_input)
 
@@ -374,7 +374,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Manage options."""
         config_entry = self.hass.config_entries.async_get_entry(self.entry_id)
         if config_entry is None:

--- a/custom_components/bayrol_cloud/manifest.json
+++ b/custom_components/bayrol_cloud/manifest.json
@@ -7,7 +7,7 @@
   "codeowners": ["@razem-io"],
   "requirements": ["beautifulsoup4==4.12.2"],
   "iot_class": "cloud_polling",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "config_flow": true,
   "license": "MIT"
 }

--- a/custom_components/bayrol_cloud/manifest.json
+++ b/custom_components/bayrol_cloud/manifest.json
@@ -7,7 +7,7 @@
   "codeowners": ["@razem-io"],
   "requirements": ["beautifulsoup4==4.12.2"],
   "iot_class": "cloud_polling",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "config_flow": true,
   "license": "MIT"
 }

--- a/custom_components/bayrol_cloud/manifest.json
+++ b/custom_components/bayrol_cloud/manifest.json
@@ -1,13 +1,12 @@
 {
   "domain": "bayrol_cloud",
   "name": "Bayrol Cloud",
-  "documentation": "https://github.com/razem-io/ha-bayrol-cloud",
-  "issue_tracker": "https://github.com/razem-io/ha-bayrol-cloud/issues",
-  "dependencies": [],
-  "codeowners": ["@razem-io"],
-  "requirements": ["beautifulsoup4==4.12.2"],
-  "iot_class": "cloud_polling",
-  "version": "0.3.1",
+  "codeowners": ["@katomm"],
   "config_flow": true,
-  "license": "MIT"
+  "dependencies": [],
+  "documentation": "https://github.com/katomm/ha-bayrol-cloud",
+  "iot_class": "cloud_polling",
+  "issue_tracker": "https://github.com/katomm/ha-bayrol-cloud/issues",
+  "requirements": ["beautifulsoup4==4.12.2"],
+  "version": "0.3.2"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,5 @@
+{
+  "name": "Bayrol Cloud",
+  "content_in_root": false,
+  "render_readme": true
+}

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,5 @@ testpaths = tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
+asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiohttp>=3.8.0
 beautifulsoup4>=4.12.0
-pytest-homeassistant-custom-component>=0.13.0
+# Pinned so CI resolves the same Home Assistant test version every run.
+pytest-homeassistant-custom-component==0.13.205

--- a/tests/test_device_parser.py
+++ b/tests/test_device_parser.py
@@ -1,0 +1,64 @@
+"""Tests for the device status parser (operation mode selects).
+
+parse_device_status extracts the controller operation modes (the i_x16 device
+blocks with their i_x7 selects). These tests cover a valid single-controller
+page and, importantly, the real-world failure mode where the Bayrol portal
+returns HTML without any i_x16 blocks: parsing must degrade to an empty result
+and log a warning, never raise.
+"""
+import logging
+
+from custom_components.bayrol_cloud.client.device_parser import parse_device_status
+
+# Minimal single-controller device page: one i_x16 device block followed by its
+# i_item sibling containing the operation-mode select (i_x7).
+SINGLE_DEVICE_HTML = """
+<div>
+  <div class="i_item item1_100"><div class="i_x16">Filter Pump</div></div>
+  <div class="i_item item3_153">
+    <select class="i_x7">
+      <option value="0" selected>Off</option>
+      <option value="1">Auto</option>
+      <option value="2">On</option>
+    </select>
+  </div>
+</div>
+"""
+
+# HTML shaped like the measurement overview (tab_box), which has no i_x16 blocks.
+# This mirrors what the portal returned when device-status parsing broke.
+NO_I_X16_HTML = (
+    '<div><div class="tab_box stat_ok"><span>pH&nbsp;[pH]</span><h1>7.20</h1></div>'
+    '<div class="tab_box stat_ok"><span>mV&nbsp;[mV]</span><h1>796</h1></div>'
+    '<div class="tab_box stat_ok"><span>T1&nbsp;[°C]</span><h1>30.6</h1></div></div>'
+)
+
+
+def test_parse_device_status_single_controller():
+    """A valid device block yields the operation mode with its selected value."""
+    data = parse_device_status(SINGLE_DEVICE_HTML)
+
+    assert "filter_pump" in data
+    entry = data["filter_pump"]
+    assert entry["name"] == "Filter Pump"
+    assert entry["item_number"] == "item3_153"
+    assert entry["current_value"] == 0
+    assert entry["current_text"] == "Off"
+    assert [opt["text"] for opt in entry["options"]] == ["Off", "Auto", "On"]
+
+
+def test_parse_device_status_no_i_x16_returns_empty(caplog):
+    """No i_x16 blocks -> empty dict plus a warning, never an exception."""
+    caplog.set_level(logging.WARNING)
+
+    data = parse_device_status(NO_I_X16_HTML)
+
+    assert data == {}
+    assert any(
+        "No device divs" in record.message for record in caplog.records
+    ), "expected a warning about missing device divs"
+
+
+def test_parse_device_status_empty_html():
+    """Empty input is handled gracefully."""
+    assert parse_device_status("") == {}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,102 @@
+"""Tests for Bayrol Cloud integration setup (async_setup_entry).
+
+These guard the setup retry behaviour: when the initial login or data fetch
+fails (for example because DNS is not ready yet right after a reboot), setup
+must raise ConfigEntryNotReady so Home Assistant retries with backoff, instead
+of returning False and staying dead until the next manual restart.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.bayrol_cloud import async_setup, async_setup_entry
+from custom_components.bayrol_cloud.const import DOMAIN
+
+
+@pytest.fixture(autouse=True)
+def _mock_clientsession():
+    """Avoid creating a real aiohttp session (the API is mocked anyway)."""
+    with patch(
+        "custom_components.bayrol_cloud.async_get_clientsession",
+        return_value=MagicMock(),
+    ):
+        yield
+
+ENTRY_DATA = {
+    "username": "user@example.com",
+    "password": "secret",
+    "cid": "12345",
+    "refresh_interval": 300,
+}
+
+POOL_DATA = {
+    "pH": 7.2,
+    "mV": 700.0,
+    "T": 28.0,
+    "status": "online",
+    "pH_alarm": False,
+    "mV_alarm": False,
+    "T_alarm": False,
+}
+
+
+def _make_api(*, login=True, get_data=None, device_status=""):
+    """Build a mocked BayrolPoolAPI with async methods."""
+    api = MagicMock()
+    api.debug_mode = False
+    api.login = AsyncMock(return_value=login)
+    api.get_data = AsyncMock(return_value=POOL_DATA if get_data is None else get_data)
+    api.get_device_status = AsyncMock(return_value=device_status)
+    return api
+
+
+def _entry(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(domain=DOMAIN, data=ENTRY_DATA, entry_id="test")
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def test_setup_raises_not_ready_when_login_fails(hass: HomeAssistant) -> None:
+    """Login never succeeds -> ConfigEntryNotReady, after exhausting retries."""
+    api = _make_api(login=False)
+    with patch("custom_components.bayrol_cloud.BayrolPoolAPI", return_value=api):
+        with pytest.raises(ConfigEntryNotReady):
+            await async_setup_entry(hass, _entry(hass))
+    # It should have retried, not given up after a single attempt.
+    assert api.login.await_count == 3
+
+
+async def test_setup_raises_not_ready_when_no_initial_data(hass: HomeAssistant) -> None:
+    """Login works but the first data fetch is empty -> ConfigEntryNotReady."""
+    api = _make_api(login=True, get_data={})
+    with patch("custom_components.bayrol_cloud.BayrolPoolAPI", return_value=api):
+        with pytest.raises(ConfigEntryNotReady):
+            await async_setup_entry(hass, _entry(hass))
+
+
+async def test_setup_raises_not_ready_on_unexpected_error(hass: HomeAssistant) -> None:
+    """An unexpected error during setup is wrapped as ConfigEntryNotReady."""
+    api = _make_api(login=True)
+    api.get_data = AsyncMock(side_effect=RuntimeError("boom"))
+    with patch("custom_components.bayrol_cloud.BayrolPoolAPI", return_value=api):
+        with pytest.raises(ConfigEntryNotReady):
+            await async_setup_entry(hass, _entry(hass))
+
+
+async def test_setup_success(hass: HomeAssistant) -> None:
+    """Happy path: coordinator is created, entry stored, platforms forwarded."""
+    api = _make_api(login=True)
+    entry = _entry(hass)
+    await async_setup(hass, {})  # initialises hass.data[DOMAIN], as HA does at boot
+    with patch("custom_components.bayrol_cloud.BayrolPoolAPI", return_value=api), patch.object(
+        hass.config_entries, "async_forward_entry_setups", AsyncMock()
+    ) as forward:
+        result = await async_setup_entry(hass, entry)
+
+    assert result is True
+    assert entry.entry_id in hass.data[DOMAIN]
+    assert "coordinator" in hass.data[DOMAIN][entry.entry_id]
+    forward.assert_awaited_once()


### PR DESCRIPTION
Fixes #22

- Replace `async_timeout.timeout()` with `asyncio.timeout()` (standard library since Python 3.11)
- Replace `FlowResult` from `homeassistant.data_entry_flow` with `ConfigFlowResult` from `homeassistant.config_entries`
- Bump version to 0.3.0